### PR TITLE
add disable and enable functions for events

### DIFF
--- a/snap.js
+++ b/snap.js
@@ -155,7 +155,7 @@
                     utils.events.removeEvent(settings.element, utils.eventType('up'), action.drag.endDrag);
                 },
                 startDrag: function(e) {
-
+                    
                     // No drag on ignored elements
                     if (e.srcElement.dataset.snapIgnore == "true") {
                         utils.dispatchEvent('ignore');
@@ -190,7 +190,7 @@
                 },
                 dragging: function(e) {
                     if (cache.isDragging) {
-
+                        
                         var thePageX = utils.hasTouch ? e.touches[0].pageX : e.pageX,
                             thePageY = utils.hasTouch ? e.touches[0].pageY : e.pageY,
                             translated = cache.translation,
@@ -199,14 +199,14 @@
                             openingLeft = absoluteTranslation > 0,
                             translateTo = whileDragX,
                             diff;
-
+                        
                         if( (cache.intentChecked && !cache.hasIntent) || // Does user show intent?
                             (thePageX-cache.startDragX)>0 && (settings.disable=='left') || // Left pane Disabled?
                             (thePageX-cache.startDragX)<0 && (settings.disable=='right') // Right pane Disabled?
                         ){
                             return;
                         }
-
+                        
                         if(settings.addBodyClasses){
                             if((absoluteTranslation)>0){
                                 doc.body.classList.add('snapjs-left');
@@ -216,7 +216,7 @@
                                 doc.body.classList.remove('snapjs-left');
                             }
                         }
-
+                        
                         if (cache.hasIntent === false || cache.hasIntent === null) {
                             var deg = utils.angleOfDrag(thePageX, thePageY),
                                 inRightRange = (deg >= 0 && deg <= settings.slideIntent) || (deg <= 360 && deg > (360 - settings.slideIntent)),
@@ -228,17 +228,17 @@
                             }
                             cache.intentChecked = true;
                         }
-
+                        
                         if (
                             (settings.minDragDistance>=Math.abs(thePageX-cache.startDragX)) && // Has user met minimum drag distance?
                             (cache.hasIntent === false)
                         ) {
                             return;
                         }
-
+                        
                         e.preventDefault();
                         utils.dispatchEvent('drag');
-
+                        
                         cache.dragWatchers.current = thePageX;
                         // Determine which direction we are going
                         if (cache.dragWatchers.last > thePageX) {

--- a/snap.js
+++ b/snap.js
@@ -149,8 +149,13 @@
                     utils.events.addEvent(settings.element, utils.eventType('move'), action.drag.dragging);
                     utils.events.addEvent(settings.element, utils.eventType('up'), action.drag.endDrag);
                 },
+                stopListening: function() {
+                    utils.events.removeEvent(settings.element, utils.eventType('down'), action.drag.startDrag);
+                    utils.events.removeEvent(settings.element, utils.eventType('move'), action.drag.dragging);
+                    utils.events.removeEvent(settings.element, utils.eventType('up'), action.drag.endDrag);
+                },
                 startDrag: function(e) {
-                    
+
                     // No drag on ignored elements
                     if (e.srcElement.dataset.snapIgnore == "true") {
                         utils.dispatchEvent('ignore');
@@ -185,7 +190,7 @@
                 },
                 dragging: function(e) {
                     if (cache.isDragging) {
-                        
+
                         var thePageX = utils.hasTouch ? e.touches[0].pageX : e.pageX,
                             thePageY = utils.hasTouch ? e.touches[0].pageY : e.pageY,
                             translated = cache.translation,
@@ -194,14 +199,14 @@
                             openingLeft = absoluteTranslation > 0,
                             translateTo = whileDragX,
                             diff;
-                        
+
                         if( (cache.intentChecked && !cache.hasIntent) || // Does user show intent?
                             (thePageX-cache.startDragX)>0 && (settings.disable=='left') || // Left pane Disabled?
                             (thePageX-cache.startDragX)<0 && (settings.disable=='right') // Right pane Disabled?
                         ){
                             return;
                         }
-                        
+
                         if(settings.addBodyClasses){
                             if((absoluteTranslation)>0){
                                 doc.body.classList.add('snapjs-left');
@@ -211,7 +216,7 @@
                                 doc.body.classList.remove('snapjs-left');
                             }
                         }
-                        
+
                         if (cache.hasIntent === false || cache.hasIntent === null) {
                             var deg = utils.angleOfDrag(thePageX, thePageY),
                                 inRightRange = (deg >= 0 && deg <= settings.slideIntent) || (deg <= 360 && deg > (360 - settings.slideIntent)),
@@ -223,17 +228,17 @@
                             }
                             cache.intentChecked = true;
                         }
-                        
-                        if ( 
+
+                        if (
                             (settings.minDragDistance>=Math.abs(thePageX-cache.startDragX)) && // Has user met minimum drag distance?
                             (cache.hasIntent === false)
                         ) {
                             return;
                         }
-                        
+
                         e.preventDefault();
                         utils.dispatchEvent('drag');
-                        
+
                         cache.dragWatchers.current = thePageX;
                         // Determine which direction we are going
                         if (cache.dragWatchers.last > thePageX) {
@@ -374,6 +379,12 @@
             if (eventList[evt]) {
                 eventList[evt] = false;
             }
+        };
+        this.enable = function() {
+            action.drag.listen();
+        };
+        this.disable = function() {
+            action.drag.stopListening();
         };
         this.state = function() {
             var state,

--- a/snap.js
+++ b/snap.js
@@ -229,7 +229,7 @@
                             cache.intentChecked = true;
                         }
                         
-                        if (
+                        if ( 
                             (settings.minDragDistance>=Math.abs(thePageX-cache.startDragX)) && // Has user met minimum drag distance?
                             (cache.hasIntent === false)
                         ) {


### PR DESCRIPTION
Hi! When my responsive layout would change from mobile sizes to something larger I wanted to disable Snap's events and instead use a different nav. And likewise, I needed to reenable the events when the window size is shrunk down to a mobile size and allow Snap to take over. So, I've added an enable and disable public functions to let me modify Snap's events at will.

Perhaps this may be useful for others. I'll leave the minify and version bumping to you!

Thanks!! And thanks for the rad library!!
