### PR TITLE
add drag disable settings

### DIFF
--- a/snap.js
+++ b/snap.js
@@ -24,6 +24,7 @@
             maxPosition: 266,
             minPosition: -266,
             tapToClose: true,
+            touchToDrag: true,
             slideIntent: 40, // degrees
             minDragDistance: 5
         },
@@ -168,6 +169,10 @@
             },
             drag: {
                 listen: function() {
+                    if(!settings.touchToDrag){
+                      return
+                    }
+
                     cache.translation = 0;
                     cache.easing = false;
                     utils.events.addEvent(settings.element, utils.eventType('down'), action.drag.startDrag);
@@ -180,7 +185,7 @@
                     utils.events.removeEvent(settings.element, utils.eventType('up'), action.drag.endDrag);
                 },
                 startDrag: function(e) {
-                    
+
                     // No drag on ignored elements
                     var src = e.target ? e.target : e.srcElement;
                     if (src.dataset && src.dataset.snapIgnore === "true") {


### PR DESCRIPTION
for some cases i dont want content can be dragging, so never listen to drag events
1. bad performance mobile, prefer using buttons and click event
2. don`t want touch events mess up
3. dom attribute dont work well for it is on e.target.
