### PR TITLE
Prevent Safari opening links when viewing as a Mobile App

### DIFF
--- a/demo/assets/demo.js
+++ b/demo/assets/demo.js
@@ -21,4 +21,4 @@ addEvent(document.getElementById('open-left'), 'click', function(){
             "href" in d && (d.href.indexOf("http") || ~d.href.indexOf(e.host)) && (a.preventDefault(), e.href = d.href)
         }, !1)
     }
-})(document, window.navigator, "standalone")
+})(document, window.navigator, "standalone");

--- a/demo/assets/demo.js
+++ b/demo/assets/demo.js
@@ -9,3 +9,16 @@ var addEvent = function addEvent(element, eventName, func) {
 addEvent(document.getElementById('open-left'), 'click', function(){
 	snapper.open('left');
 });
+
+/* Prevent Safari opening links when viewing as a Mobile App */
+(function (a, b, c) {
+    if(c in b && b[c]) {
+        var d, e = a.location,
+            f = /^(a|html)$/i;
+        a.addEventListener("click", function (a) {
+            d = a.target;
+            while(!f.test(d.nodeName)) d = d.parentNode;
+            "href" in d && (d.href.indexOf("http") || ~d.href.indexOf(e.host)) && (a.preventDefault(), e.href = d.href)
+        }, !1)
+    }
+})(document, window.navigator, "standalone")


### PR DESCRIPTION
Prevents the demo apps links from opening in Safari when viewing as a Mobile App

From this post http://chiefcreative.me/post/48945447409/make-website-behave-as-ios-web-app#.UYTL57WsiSo 
Number 5
