### PR TITLE
Added new settings configuration called "dragElement" to allow the user to drag a different element (title bar for example)

### DIFF
--- a/snap.js
+++ b/snap.js
@@ -435,6 +435,9 @@
             }
         },
         init = function(opts) {
+            // Default back to the element setting if dragElement was not set
+            opts.dragElement = opts.dragElement || opts.element;
+
             if (opts.element) {
                 utils.deepExtend(settings, opts);
                 cache.vendor = utils.vendor();

--- a/snap.js
+++ b/snap.js
@@ -15,6 +15,7 @@
     var Snap = Snap || function(userOpts) {
         var settings = {
             element: null,
+            dragElement: null,
             disable: 'none',
             addBodyClasses: true,
             resistance: 0.5,
@@ -56,7 +57,7 @@
                 return eventTypes[action];
             },
             page: function(t, e){
-                return (utils.hasTouch && e.touches.length && e.touches[0]) ? e.touches[0]['page'+t] : e['page'+t];
+                return (utils.hasTouch && e.touches && e.touches.length && e.touches[0]) ? e.touches[0]['page'+t] : e['page'+t];
             },
             klass: {
                 has: function(el, name){
@@ -231,14 +232,14 @@
                 listen: function() {
                     cache.translation = 0;
                     cache.easing = false;
-                    utils.events.addEvent(settings.element, utils.eventType('down'), action.drag.startDrag);
-                    utils.events.addEvent(settings.element, utils.eventType('move'), action.drag.dragging);
-                    utils.events.addEvent(settings.element, utils.eventType('up'), action.drag.endDrag);
+                    utils.events.addEvent(settings.dragElement, utils.eventType('down'), action.drag.startDrag);
+                    utils.events.addEvent(settings.dragElement, utils.eventType('move'), action.drag.dragging);
+                    utils.events.addEvent(settings.dragElement, utils.eventType('up'), action.drag.endDrag);
                 },
                 stopListening: function() {
-                    utils.events.removeEvent(settings.element, utils.eventType('down'), action.drag.startDrag);
-                    utils.events.removeEvent(settings.element, utils.eventType('move'), action.drag.dragging);
-                    utils.events.removeEvent(settings.element, utils.eventType('up'), action.drag.endDrag);
+                    utils.events.removeEvent(settings.dragElement, utils.eventType('down'), action.drag.startDrag);
+                    utils.events.removeEvent(settings.dragElement, utils.eventType('move'), action.drag.dragging);
+                    utils.events.removeEvent(settings.dragElement, utils.eventType('up'), action.drag.endDrag);
                 },
                 startDrag: function(e) {
                     // No drag on ignored elements
@@ -529,3 +530,4 @@
         });
     }
 }).call(this, window, document);
+


### PR DESCRIPTION
Added new dragElement setting. Defaults back to "element" on the init call if it is null. Additionally, I am removing my previous pull request to check the event touches property, and rolling it into this pull request instead.
