### PR TITLE
Update snap.js

### DIFF
--- a/snap.js
+++ b/snap.js
@@ -249,12 +249,16 @@
                     cache.translation = 0;
                     cache.easing = false;
                     utils.events.addEvent(settings.element, utils.eventType('down'), action.drag.startDrag);
-                    utils.events.addEvent(settings.element, utils.eventType('move'), action.drag.dragging);
+                    if (utils.hasTouch) {
+    	                    utils.events.addEvent(settings.element, utils.eventType('move'), action.drag.dragging);
+		            }
                     utils.events.addEvent(settings.element, utils.eventType('up'), action.drag.endDrag);
                 },
                 stopListening: function() {
                     utils.events.removeEvent(settings.element, utils.eventType('down'), action.drag.startDrag);
-                    utils.events.removeEvent(settings.element, utils.eventType('move'), action.drag.dragging);
+                    if (utils.hasTouch) {
+                        utils.events.removeEvent(settings.element, utils.eventType('move'), action.drag.dragging);
+                    }
                     utils.events.removeEvent(settings.element, utils.eventType('up'), action.drag.endDrag);
                 },
                 startDrag: function(e) {
@@ -267,6 +271,9 @@
                         return;
                     }
                     
+                	if (!utils.hasTouch) {
+						 utils.events.addEvent(settings.element, utils.eventType('move'), action.drag.dragging);
+					}
                     
                     if(settings.dragger){
                         var dragParent = utils.parentUntil(target, settings.dragger);
@@ -414,6 +421,10 @@
                     }
                 },
                 endDrag: function(e) {
+                    if (!utils.hasTouch) {
+						 utils.events.removeEvent(settings.element, utils.eventType('move'), action.drag.dragging);
+					}
+
                     if (cache.isDragging) {
                         utils.dispatchEvent('end');
                         var translated = action.translate.get.matrix(4);


### PR DESCRIPTION
Save desktop cpus lots of cycles (and events), if you start registering 'mousemove' events AFTER at least 1 'mousedown' event occured. 
Remove the listener after mouse up.
