### PR TITLE
Extending disabled option to accept 'both'

### DIFF
--- a/snap.js
+++ b/snap.js
@@ -217,7 +217,8 @@
                 },
                 x: function(n) {
                     if( (settings.disable==='left' && n>0) ||
-                        (settings.disable==='right' && n<0)
+                        (settings.disable==='right' && n<0) ||
+                        (settings.disable==='both')
                     ){ return; }
                     
                     if( !settings.hyperextensible ){


### PR DESCRIPTION
Now accepting disabled: "both" to disable left and right swipe on the fly by just updating the setting.
