### PR TITLE
Fix issues with IE9

### DIFF
--- a/snap.js
+++ b/snap.js
@@ -163,7 +163,7 @@
                 get: {
                     matrix: function(index) {
 
-                        if( !utils.canTransform() ){
+                        if( !cache.canTransform ){
                             return parseInt(settings.element.style.left, 10);
                         } else {
                             var matrix = win.getComputedStyle(settings.element)[cache.vendor+'Transform'].match(/\((.*)\)/),
@@ -195,7 +195,7 @@
                 },
                 easeTo: function(n) {
 
-                    if( !utils.canTransform() ){
+                    if( !cache.canTransform ){
                         cache.translation = n;
                         action.translate.x(n);
                     } else {
@@ -210,10 +210,11 @@
                         
                         utils.events.addEvent(settings.element, utils.transitionCallback(), action.translate.easeCallback);
                         action.translate.x(n);
-                    }
-                    if(n===0){
+
+                        if(n===0){
                            settings.element.style[cache.vendor+'Transform'] = '';
-                       }
+                        }
+                    }
                 },
                 x: function(n) {
                     if( (settings.disable==='left' && n>0) ||
@@ -233,7 +234,7 @@
                         n = 0;
                     }
 
-                    if( utils.canTransform() ){
+                    if( cache.canTransform ){
                         var theTranslate = 'translate3d(' + n + 'px, 0,0)';
                         settings.element.style[cache.vendor+'Transform'] = theTranslate;
                     } else {
@@ -281,7 +282,10 @@
                     }
                     
                     utils.dispatchEvent('start');
-                    settings.element.style[cache.vendor+'Transition'] = '';
+
+                    if(cache.canTransform) {
+                        settings.element.style[cache.vendor+'Transition'] = '';
+                    }
                     cache.isDragging = true;
                     cache.hasIntent = null;
                     cache.intentChecked = false;
@@ -468,6 +472,7 @@
             if (opts.element) {
                 utils.deepExtend(settings, opts);
                 cache.vendor = utils.vendor();
+                cache.canTransform = utils.canTransform();
                 action.drag.listen();
             }
         };


### PR DESCRIPTION
- Cache canTransform
- Wrap all access to CSS Transform with if(canTransform) { .. }
  §
