### PR TITLE
Urgent: Bug fix hasTouch check. Not possible do use document.ontouchstart

### DIFF
--- a/snap.js
+++ b/snap.js
@@ -47,7 +47,7 @@
         },
         eventList = {},
         utils = {
-            hasTouch: (doc.ontouchstart === null),
+            hasTouch: ('ontouchstart' in document.documentElement || window.navigator.msPointerEnabled),
             eventType: function(action) {
                 var eventTypes = {
                         down: (utils.hasTouch ? 'touchstart' : 'mousedown'),


### PR DESCRIPTION
Not possible to use document.ontouchstart check, because this does not work if ontouchstart method is used to catch touches on document. Added proper check for "ontouchstart" method.

Please patch this ASAP.
