### PR TITLE
Add `noMultiTouch` option to prevent reacting to multi touch events

### DIFF
--- a/snap.js
+++ b/snap.js
@@ -192,6 +192,7 @@
                     if(cache.easingTo===0){
                         utils.klass.remove(doc.body, 'snapjs-right');
                         utils.klass.remove(doc.body, 'snapjs-left');
+                        utils.dispatchEvent('snapperClosed');
                     }
 
                     utils.dispatchEvent('animated');

--- a/snap.js
+++ b/snap.js
@@ -27,6 +27,7 @@
             minPosition: -266,
             tapToClose: true,
             touchToDrag: true,
+            noMultiTouch: true,
             slideIntent: 40, // degrees
             minDragDistance: 5
         },
@@ -48,6 +49,9 @@
         eventList = {},
         utils = {
             hasTouch: ('ontouchstart' in doc.documentElement || win.navigator.msPointerEnabled),
+            isMultiTouch: function(event) {
+                return event.touches && event.touches.length > 1;
+            },
             eventType: function(action) {
                 var eventTypes = {
                         down: (utils.hasTouch ? 'touchstart' : 'mousedown'),
@@ -262,7 +266,7 @@
                     var target = e.target ? e.target : e.srcElement,
                         ignoreParent = utils.parentUntil(target, 'data-snap-ignore');
                     
-                    if (ignoreParent) {
+                    if (ignoreParent || (settings.noMultiTouch && utils.isMultiTouch(e))) {
                         utils.dispatchEvent('ignore');
                         return;
                     }


### PR DESCRIPTION
This adds a new setting noMultiTouch and makes it the default.
With `noMultiTouch` set to true snap.js won't react to multi
finger gestures. This should be the default as it's quite unlikely
to be what the user expects. It helps to prevent issues
with other gestures like pinch zooming.
