### PR TITLE
When it was drag, the close and open events are not fired.

### DIFF
--- a/snap.js
+++ b/snap.js
@@ -434,14 +434,17 @@
                             if ((cache.simpleStates.halfway || cache.simpleStates.hyperExtending || cache.simpleStates.flick)) {
                                 if (cache.simpleStates.flick && cache.simpleStates.towards === 'left') { // Flicking Closed
                                     action.translate.easeTo(0);
+                                    utils.dispatchEvent('close');
                                 } else if (
                                     (cache.simpleStates.flick && cache.simpleStates.towards === 'right') || // Flicking Open OR
                                     (cache.simpleStates.halfway || cache.simpleStates.hyperExtending) // At least halfway open OR hyperextending
                                 ) {
                                     action.translate.easeTo(settings.maxPosition); // Open Left
+                                    utils.dispatchEvent('open');
                                 }
                             } else {
                                 action.translate.easeTo(0); // Close Left
+                                utils.dispatchEvent('close');
                             }
                             // Revealing Right
                         } else if (cache.simpleStates.opening === 'right') {
@@ -449,14 +452,17 @@
                             if ((cache.simpleStates.halfway || cache.simpleStates.hyperExtending || cache.simpleStates.flick)) {
                                 if (cache.simpleStates.flick && cache.simpleStates.towards === 'right') { // Flicking Closed
                                     action.translate.easeTo(0);
+                                    utils.dispatchEvent('close');
                                 } else if (
                                     (cache.simpleStates.flick && cache.simpleStates.towards === 'left') || // Flicking Open OR
                                     (cache.simpleStates.halfway || cache.simpleStates.hyperExtending) // At least halfway open OR hyperextending
                                 ) {
                                     action.translate.easeTo(settings.minPosition); // Open Right
+                                    utils.dispatchEvent('open');
                                 }
                             } else {
                                 action.translate.easeTo(0); // Close Right
+                                utils.dispatchEvent('close');
                             }
                         }
                         cache.isDragging = false;


### PR DESCRIPTION
When it was drag to close, the close event is not fired. It only happens when tap to close, or when it's called.

In the docs it says "close: Fired when close is called directly or if tapToClose is set to true", but this happened.
