### PR TITLE
Check for vendor in canTransform()

### DIFF
--- a/snap.js
+++ b/snap.js
@@ -237,8 +237,6 @@
                         var theTranslate = 'translate3d(' + n + 'px, 0,0)';
                         settings.element.style[cache.vendor+'Transform'] = theTranslate;
                     } else {
-                        settings.element.style.width = (doc.documentElement.clientWidth || win.innerWidth)+'px';
-
                         settings.element.style.left = n+'px';
                         settings.element.style.right = '';
                     }

--- a/snap.js
+++ b/snap.js
@@ -237,7 +237,7 @@
                         var theTranslate = 'translate3d(' + n + 'px, 0,0)';
                         settings.element.style[cache.vendor+'Transform'] = theTranslate;
                     } else {
-                        settings.element.style.width = (win.innerWidth || doc.documentElement.clientWidth)+'px';
+                        settings.element.style.width = (doc.documentElement.clientWidth || win.innerWidth)+'px';
 
                         settings.element.style.left = n+'px';
                         settings.element.style.right = '';

--- a/snap.js
+++ b/snap.js
@@ -94,7 +94,7 @@
                 return (cache.vendor==='Moz' || cache.vendor==='ms') ? 'transitionend' : cache.vendor+'TransitionEnd';
             },
             canTransform: function(){
-                return typeof settings.element.style[cache.vendor+'Transform'] !== 'undefined';
+                return !!(cache.vendor && typeof settings.element.style[cache.vendor+'Transform'] !== 'undefined');
             },
             deepExtend: function(destination, source) {
                 var property;


### PR DESCRIPTION
Check for the existing vendor value before looking at the element styling. This should prevent IE9 from falsely reporting Transform capabilities in certain situations.
