### PR TITLE
Wrong opening state in the first frame of dragging event

### DIFF
--- a/src/snap.js
+++ b/src/snap.js
@@ -490,6 +490,7 @@
                             absoluteTranslation = action.translate.get.matrix(4),
                             whileDragX = thePageX - cache.startDragX,
                             openingLeft = absoluteTranslation > 0,
+                            openingRight = absoluteTranslation < 0,
                             translateTo = whileDragX,
                             diff;
 
@@ -566,7 +567,7 @@
                                     percentage: (absoluteTranslation/settings.maxPosition)*100
                                 }
                             };
-                        } else {
+                        } else if (openingRight) {
                             // Pulling too far to the left
                             if (settings.minPosition > absoluteTranslation) {
                                 diff = (absoluteTranslation - settings.minPosition) * settings.resistance;


### PR DESCRIPTION
When you start dragging **_to the right**_ in the first frame the absoluteTranslation variable of dragging() function will be 0. So openingLeft variable becomes false. This cause snap object's opening state unconformity: it becomes 'right', but only in the first event call. 

I think it will be more correctly not to initialize state when absoluteTranslation is 0, cause we cannot exactly determine the direction of drag in the first frame.
