### PR TITLE
Hot fix for elements with position:fixed inside the .snap-content container

### DIFF
--- a/snap.css
+++ b/snap.css
@@ -18,11 +18,17 @@ html, body {
   z-index: 2;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
+  /*
+  Fix for divs with position:fixed inside the snap-content scroll problem:
+  http://stackoverflow.com/questions/15194313/webkit-css-transform3d-position-fixed-issue
+
+  More info: http://meyerweb.com/eric/thoughts/2011/09/12/un-fixing-fixed-elements-with-css-transforms/
   -webkit-transform: translate3d(0, 0, 0);
      -moz-transform: translate3d(0, 0, 0);
       -ms-transform: translate3d(0, 0, 0);
        -o-transform: translate3d(0, 0, 0);
           transform: translate3d(0, 0, 0);
+  */
 }
 
 .snap-drawers {


### PR DESCRIPTION
This will try to fix the issue with elements having position:fixed inside the snap-content, which makes them scroll with the page. Though it is a temporary solution it will show the fixed elements correctly when the menu is closed. The better solution maybe would be to add another layer for the fixed element on top of the snap-content div.

---

Fix for divs with position:fixed inside the snap-content scroll problem:
http://stackoverflow.com/questions/15194313/webkit-css-transform3d-position-fixed-issue

More info: http://meyerweb.com/eric/thoughts/2011/09/12/un-fixing-fixed-elements-with-css-transforms/
